### PR TITLE
fix: GDAL axis ordering mismatch causes coordinate transformation failure

### DIFF
--- a/methods/main/PolygonizationWorker.py
+++ b/methods/main/PolygonizationWorker.py
@@ -36,6 +36,8 @@ class PolygonizationWorker:
         
         equal_area_srs = osr.SpatialReference()
         equal_area_srs.ImportFromEPSG(6933)
+        srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        equal_area_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         coord_transform = osr.CoordinateTransformation(srs, equal_area_srs)
 
         height, width = array.shape

--- a/methods/main/inference.py
+++ b/methods/main/inference.py
@@ -354,6 +354,8 @@ def postdelineation_merge(layer_info, filter_config):
         src_srs = layer.GetSpatialRef()
         dst_src = osr.SpatialReference()
         dst_src.ImportFromEPSG(6933)
+        src_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        dst_src.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
         transform = osr.CoordinateTransformation(src_srs, dst_src)
 


### PR DESCRIPTION
fixed GDAL axis ordering mismatch causes coordinate transformation failure #18 