### PR TITLE
fix: dissolve_inplace loses feature attributes when merging duplicates

### DIFF
--- a/simplification/simplify.py
+++ b/simplification/simplify.py
@@ -248,8 +248,10 @@ def dissolve_inplace(input_gpkg, layername, field_name):
         ds = None
         return
 
-    # --- Step 2: Collect geometries for those values ---
+    # --- Step 2: Collect geometries and attributes for those values ---
+    defn = layer.GetLayerDefn()
     groups = {val: None for val in multi_vals}
+    group_attrs = {}
     fids_to_delete = []
     layer.ResetReading()
 
@@ -261,6 +263,12 @@ def dissolve_inplace(input_gpkg, layername, field_name):
                 geom = geom.Clone()
                 if groups[val] is None:
                     groups[val] = geom
+                    attrs = {}
+                    for i in range(defn.GetFieldCount()):
+                        fname = defn.GetFieldDefn(i).GetName()
+                        if fname != field_name:
+                            attrs[fname] = feat.GetField(i)
+                    group_attrs[val] = attrs
                 else:
                     groups[val] = groups[val].Union(geom)
             fids_to_delete.append(feat.GetFID())
@@ -273,7 +281,6 @@ def dissolve_inplace(input_gpkg, layername, field_name):
         layer.DeleteFeature(fid)
 
     # Insert dissolved features
-    defn = layer.GetLayerDefn()
     for val, geom in tqdm(groups.items(), desc="Inserting"):
         if geom is None:
             continue
@@ -284,6 +291,9 @@ def dissolve_inplace(input_gpkg, layername, field_name):
         new_feat = ogr.Feature(defn)
         new_feat.SetField(field_name, val)
         new_feat.SetGeometry(geom)
+        if val in group_attrs:
+            for fname, fval in group_attrs[val].items():
+                new_feat.SetField(fname, fval)
         layer.CreateFeature(new_feat)
         new_feat = None
 


### PR DESCRIPTION
## Bug

`simplification/simplify.py`'s `dissolve_inplace` function only sets `GEN_FID` and geometry when merging duplicate features. All other attribute fields (`bg`, `area`, etc.) are lost as null.

**Root cause:** During simplification, a feature spanning multiple blocks is written multiple times (each `SimplificationWorker` processes blocks independently, `WriteWorker` does not deduplicate). `dissolve_inplace` is responsible for merging these duplicates, but when creating the dissolved feature, it does not copy the original attribute values.

## Fix

In Step 2, while collecting geometries, also save the attribute values from the first feature of each group. In Step 4, when creating the dissolved feature, write the saved attribute values.

## Verification

Before fix: 59 out of 983 features have `bg=null`, `area=null` after simplification
After fix: All 983 features have `bg=0` and valid `area` values